### PR TITLE
ensure sleep() in main() is not given a negative value

### DIFF
--- a/conviron/__main__.py
+++ b/conviron/__main__.py
@@ -122,7 +122,10 @@ def main():
                     ))
                 )
         diff = csv_time - previous_time 
-        wait_sec = diff.days * 24 * 60 * 60 + diff.seconds - prev_run_length
+        wait_sec = max(
+                diff.days * 24 * 60 * 60 + diff.seconds - prev_run_length,
+                0  # We don't want to wait a negative number of seconds
+                )
         if config.getboolean("Global", "Debug"):
             print("Waiting %i secs." % wait_sec)
         sleep(wait_sec)


### PR DESCRIPTION
In fixing #3, i allowed a negative number of seconds to be passed to `time.sleep()`. This PR fixes this bug.
