### PR TITLE
Fix #19, solve monitor SQL bug

### DIFF
--- a/conviron/monitor/__init__.py
+++ b/conviron/monitor/__init__.py
@@ -33,6 +33,8 @@ def _poll_database(chamber):
         return result
     except Exception as e:
         traceback_text = traceback.format_exc()
+        if monitor_config.getboolean("Monitor", "Debug"):
+            print(traceback_text)
         email_error("Error polling database", traceback_text, monitor_config_file)
 
 
@@ -69,7 +71,8 @@ def main():
                     error = "Chamber %s FAIL:\nToo long since good ping: %i > %i" % \
                             (chamber, sec_since_good_result, interval,)
                 else:
-                    print("Chamber %s OK" % chamber)
+                    print("%s: Chamber %s OK" %
+                            (datetime.now().isoformat(), chamber))
             except IndexError:
                 error = "Chamber %s FAIL:\nNo database log records for chamber" % chamber
             if error is not None:

--- a/monitor.ini
+++ b/monitor.ini
@@ -1,4 +1,5 @@
 [Monitor]
+Debug = False
 ChambersToMonitor = 2,3,4,5
 # Interval is in seconds, strongly recommend adding 10% of true interval
 ChamberIntervals = 66,66,66,66


### PR DESCRIPTION
Parameters were passed incorrectly to the cur.execute() calls, must be passed as a tuple, even if there's only one parameter:
`cur.execute(query, (param,))` NOT `cur.execute(query, param)`

Also pulling enchanced debug message reporting in the monitor main loop.
K
