### PR TITLE
convrion module crashes disingenously if no csv is specified

### DIFF
--- a/conviron/__main__.py
+++ b/conviron/__main__.py
@@ -100,6 +100,7 @@ def main():
                 "Usage:\n"
                 "\tpython3 -m convrion <csv_file> [<ini.file>]"
                 )
+        exit(-1)
 
     csv_reader = csv.reader(csv_fh, delimiter=',',
             quoting=csv.QUOTE_NONE)


### PR DESCRIPTION
Traceback below. A missing call to `exit()` was to blame

`````` PYTHONPATH=/home/kevin/prog/bio/conviron
ERROR: csv file must exist
Usage:
    python3 -m convrion <csv_file> [<ini.file>]
Traceback (most recent call last):
  File "/usr/lib/python3.2/runpy.py", line 161, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python3.2/runpy.py", line 74, in _run_code
    exec(code, run_globals)
  File "/home/kevin/prog/bio/conviron/conviron/__main__.py", line 185, in <module>
    main()
  File "/home/kevin/prog/bio/conviron/conviron/__main__.py", line 98, in main
    csv_reader = csv.reader(csv_fh, delimiter=',',
UnboundLocalError: local variable 'csv_fh' referenced before assignment```
``````
