### PR TITLE
add LIMIT 50 to database polling SQL statements

### DIFF
--- a/monitor.ini
+++ b/monitor.ini
@@ -19,5 +19,5 @@ Port = 5432
 User = conviron
 Pass = P^$$
 InsertStatement = INSERT INTO conviron_log (chamber, error, log) VALUES (%%s, %%s, %%s)
-SelectLogPassesStatement = SELECT timestamp, chamber, error, log FROM conviron_log WHERE chamber = %%s AND error = FALSE ORDER BY timestamp DESC
-SelectLogStatement = SELECT timestamp, chamber, error, log FROM conviron_log WHERE chamber = %%s ORDER BY timestamp DESC
+SelectLogPassesStatement = SELECT timestamp, chamber, error, log FROM conviron_log WHERE chamber = %%s AND error = FALSE ORDER BY timestamp DESC LIMIT 50
+SelectLogStatement = SELECT timestamp, chamber, error, log FROM conviron_log WHERE chamber = %%s ORDER BY timestamp DESC LIMIT 50


### PR DESCRIPTION
This will stop the entire history log from the database being downloaded every minute or two.
